### PR TITLE
Ignore cache data for any requests that don't have an etag.

### DIFF
--- a/OctoKit/OCTClient.m
+++ b/OctoKit/OCTClient.m
@@ -125,7 +125,10 @@ static const NSUInteger OCTClientNotModifiedStatusCode = 304;
 	NSMutableURLRequest *request = [self requestWithMethod:method path:[path stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding] parameters:parameters];
 	if (etag != nil) {
 		[request setValue:etag forHTTPHeaderField:@"If-None-Match"];
-	}
+	} else {
+        // ignore cache data so we definitely re-fatch from the server
+        request.cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
+    }
 
 	return [self enqueueRequest:request resultClass:resultClass fetchAllPages:fetchAllPages];
 }


### PR DESCRIPTION
The default cachePolicy of NSURLRequestUseProtocolCachePolicy will return a cached response of the GET request to /user even if the authorization header has changed.

The documentation for `-enqueueConditionalRequestWithMethod:(NSString *)method path:(NSString *)path parameters:(NSDictionary *)parameters notMatchingEtag:(NSString *)etag resultClass:(Class)resultClass` states that if `notMatchingEtag` is nil the latest data will be fetched.

So this change just makes that strictly true.
