### PR TITLE
Improve logging, fix handling of 304 Not Modified

### DIFF
--- a/OctoKit/OCTClient.m
+++ b/OctoKit/OCTClient.m
@@ -131,7 +131,12 @@ static const NSInteger OCTClientNotModifiedStatusCode = 304;
 	NSMutableURLRequest *request = [self requestWithMethod:method path:[path stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding] parameters:parameters];
 	if (etag != nil) {
 		[request setValue:etag forHTTPHeaderField:@"If-None-Match"];
+
+		// If an etag is specified, we want 304 responses to be treated as 304s,
+		// not served from NSURLCache with a status of 200.
+		request.cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
 	}
+
 	return request;
 }
 


### PR DESCRIPTION
The root of the problem seems to be that `NSURLConnection` would interpret a `304 Not Modified` as a need to satisfy from it from the cache, so we'd end up with a 200 status and cached data. This fixes etag requests to never use the cache.
