### PR TITLE
Make all OCTEntity properties atomic

### DIFF
--- a/OctoKit/OCTEntity.h
+++ b/OctoKit/OCTEntity.h
@@ -14,12 +14,12 @@
 @interface OCTEntity : OCTObject
 
 // The unique name for this entity, used in GitHub URLs.
-@property (nonatomic, copy, readonly) NSString *login;
+@property (atomic, copy, readonly) NSString *login;
 
 // The full name of this entity.
 //
 // Returns `login` if no name is explicitly set.
-@property (nonatomic, copy, readonly) NSString *name;
+@property (atomic, copy, readonly) NSString *name;
 
 // The OCTRepository objects associated with this entity.
 //
@@ -28,31 +28,31 @@
 @property (atomic, copy) NSArray *repositories;
 
 // The email address for this account.
-@property (nonatomic, copy, readonly) NSString *email;
+@property (atomic, copy, readonly) NSString *email;
 
 // The URL for any avatar image.
-@property (nonatomic, copy, readonly) NSURL *avatarURL;
+@property (atomic, copy, readonly) NSURL *avatarURL;
 
 // A reference to a blog associated with this account.
-@property (nonatomic, copy, readonly) NSString *blog;
+@property (atomic, copy, readonly) NSString *blog;
 
 // The name of a company associated with this account.
-@property (nonatomic, copy, readonly) NSString *company;
+@property (atomic, copy, readonly) NSString *company;
 
 // The total number of collaborators that this account has on their private repositories.
-@property (nonatomic, assign, readonly) NSUInteger collaborators;
+@property (atomic, assign, readonly) NSUInteger collaborators;
 
 // The number of public repositories owned by this account.
-@property (nonatomic, assign, readonly) NSUInteger publicRepoCount;
+@property (atomic, assign, readonly) NSUInteger publicRepoCount;
 
 // The number of private repositories owned by this account.
-@property (nonatomic, assign, readonly) NSUInteger privateRepoCount;
+@property (atomic, assign, readonly) NSUInteger privateRepoCount;
 
 // The number of kilobytes occupied by this account's repositories on disk.
-@property (nonatomic, assign, readonly) NSUInteger diskUsage;
+@property (atomic, assign, readonly) NSUInteger diskUsage;
 
 // The plan that this account is on.
-@property (nonatomic, strong, readonly) OCTPlan *plan;
+@property (atomic, strong, readonly) OCTPlan *plan;
 
 // Updates the receiver's repositories with data from the set of remote
 // repositories.


### PR DESCRIPTION
In GHfM, we merge entities in several places. Merging isn't actually safe to do unless the properties are atomic. We could probably even use larger-scale synchronization, but this should be good enough to avoid crashes.
