### PR TITLE
Use the application/vnd.github.v3 content-type

### DIFF
--- a/OctoKit/OCTClient.m
+++ b/OctoKit/OCTClient.m
@@ -112,8 +112,9 @@ static const NSInteger OCTClientNotModifiedStatusCode = 304;
 	if (self == nil) return nil;
 	
 	self.parameterEncoding = AFJSONParameterEncoding;
+	[AFJSONRequestOperation addAcceptableContentTypes:[NSSet setWithObject:@"application/vnd.github.beta+json"]];
 	[self registerHTTPOperationClass:AFJSONRequestOperation.class];
-	[self setDefaultHeader:@"Accept" value:@"application/json"];
+	[self setDefaultHeader:@"Accept" value:@"application/vnd.github.beta+json"];
 	[AFHTTPRequestOperation addAcceptableStatusCodes:[NSIndexSet indexSetWithIndex:OCTClientNotModifiedStatusCode]];
 
 	return self;


### PR DESCRIPTION
http://developer.github.com/v3/media/

> Neither of these specify a version, so you will always get the latest JSON representation of resources. If you’re building an application and care about the stability of the API, specify a version like so:

I'm not sure if v3 is the correct version to use, I have not tested every single endpoint. Someone with more knowledge of this API client will have to confirm, but it should definitely use the correct content type. For compatibility reasons.
