### PR TITLE
Add the URL property to pull request objects.

### DIFF
--- a/OctoKit/OCTPullRequest.h
+++ b/OctoKit/OCTPullRequest.h
@@ -20,6 +20,9 @@ typedef enum : NSUInteger {
 // A pull request on a repository.
 @interface OCTPullRequest : OCTObject
 
+// The api URL for this pull request.
+@property (nonatomic, copy, readonly) NSURL *URL;
+
 // The webpage URL for this pull request.
 @property (nonatomic, copy, readonly) NSURL *HTMLURL;
 

--- a/OctoKit/OCTPullRequest.m
+++ b/OctoKit/OCTPullRequest.m
@@ -14,12 +14,17 @@
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return [super.JSONKeyPathsByPropertyKey mtl_dictionaryByAddingEntriesFromDictionary:@{
+		@"URL" : @"url",
 		@"HTMLURL": @"html_url",
 		@"diffURL": @"diff_url",
 		@"patchURL": @"patch_url",
 		@"issueURL": @"issue_url",
 		@"objectID": @"number",
 	}];
+}
+
++ (NSValueTransformer *)URLJSONTransformer {
+	return [NSValueTransformer valueTransformerForName:MTLURLValueTransformerName];
 }
 
 + (NSValueTransformer *)HTMLURLJSONTransformer {

--- a/OctoKitTests/OCTPullRequestSpec.m
+++ b/OctoKitTests/OCTPullRequestSpec.m
@@ -153,6 +153,7 @@ itShouldBehaveLike(OCTObjectArchivingSharedExamplesName, ^{
 
 it(@"should initialize", ^{
 	expect(pullRequest.objectID).to.equal(@"1");
+	expect(pullRequest.URL).to.equal([NSURL URLWithString:@"https://api.github.com/octocat/Hello-World/pulls/1"]);
 	expect(pullRequest.HTMLURL).to.equal([NSURL URLWithString:@"https://github.com/octocat/Hello-World/pulls/1"]);
 	expect(pullRequest.diffURL).to.equal([NSURL URLWithString:@"https://github.com/octocat/Hello-World/pulls/1.diff"]);
 	expect(pullRequest.patchURL).to.equal([NSURL URLWithString:@"https://github.com/octocat/Hello-World/pulls/1.patch"]);


### PR DESCRIPTION
This URL is actually kind of useful because it can be used to fetch the pull request with different media types.
