### PR TITLE
Don't cache authorization requests.

### DIFF
--- a/OctoKit/OCTClient.m
+++ b/OctoKit/OCTClient.m
@@ -516,6 +516,7 @@ static NSString * const OCTClientOneTimePasswordHeaderField = @"X-GitHub-OTP";
 	// they're both sent to the server the same way: as the Basic Auth password.
 	OCTClient *authedClient = [OCTClient authenticatedClientWithUser:self.user token:password];
 	NSMutableURLRequest *request = [authedClient requestWithMethod:method path:path parameters:parameters];
+	request.cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
 	if (oneTimePassword != nil) [request setValue:oneTimePassword forHTTPHeaderField:OCTClientOneTimePasswordHeaderField];
 
 	return [[self


### PR DESCRIPTION
Otherwise NSURLCache will add a "If-Not-Matching" header which can
result in a 412 from the server.
