### PR TITLE
Add the syncronize action for pull request events

### DIFF
--- a/OctoKit/OCTIssueEvent.h
+++ b/OctoKit/OCTIssueEvent.h
@@ -12,17 +12,23 @@
 
 // The type of action performed on an issue or pull request.
 //
-// OCTIssueActionUnknown  - An unknown action occurred. Issue events will
-//                          never be initialized with this value -- they
-//                          will simply fail to be created.
-// OCTIssueActionOpened   - The issue or pull request was opened.
-// OCTIssueActionClosed   - The issue or pull request was closed.
-// OCTIssueActionReopened - The issue or pull request was reopened.
+// OCTIssueActionUnknown      - An unknown action occurred. Issue events will
+//                              never be initialized with this value -- they
+//                              will simply fail to be created.
+// OCTIssueActionOpened       - The issue or pull request was opened.
+// OCTIssueActionClosed       - The issue or pull request was closed.
+// OCTIssueActionReopened     - The issue or pull request was reopened.
+// OCTIssueActionSynchronized - Only available on pull request events. This
+//                              action occurs when a pull request is forcibly
+//                              sync'd with the underlying git state after a
+//                              failed hook or a force push.
+
 typedef enum : NSUInteger {
     OCTIssueActionUnknown = 0,
     OCTIssueActionOpened,
     OCTIssueActionClosed,
-    OCTIssueActionReopened
+    OCTIssueActionReopened,
+    OCTIssueActionSynchronized
 } OCTIssueAction;
 
 // An issue was opened or closed or somethin'.

--- a/OctoKit/OCTPullRequestEvent.m
+++ b/OctoKit/OCTPullRequestEvent.m
@@ -29,6 +29,7 @@
 		@"opened": @(OCTIssueActionOpened),
 		@"closed": @(OCTIssueActionClosed),
 		@"reopened": @(OCTIssueActionReopened),
+		@"synchronized": @(OCTIssueActionSynchronized),
 	};
 
 	return [MTLValueTransformer


### PR DESCRIPTION
According to the [docs](http://developer.github.com/v3/activity/events/types/#pullrequestevent) there is a "synchronize" event that can occur on pull_request events. 

I'll admit that part of the reason I'm opening this PR is so someone can explain to me what the synchronize action is.
