### PR TITLE
Make pull request review comments a subclass of issue comments.

### DIFF
--- a/OctoKit/OCTPullRequestComment.h
+++ b/OctoKit/OCTPullRequestComment.h
@@ -7,13 +7,11 @@
 //
 
 #import "OCTObject.h"
+#import "OCTIssueComment.h"
 #import "OCTReviewComment.h"
 
 // A single comment on a pull request.
-@interface OCTPullRequestComment : OCTObject <OCTReviewComment>
-
-// The webpage URL for this comment.
-@property (nonatomic, copy, readonly) NSURL *HTMLURL;
+@interface OCTPullRequestComment : OCTIssueComment <OCTReviewComment>
 
 // The API URL for the pull request upon which this comment appears.
 @property (nonatomic, copy, readonly) NSURL *pullRequestAPIURL;

--- a/OctoKit/OCTPullRequestComment.m
+++ b/OctoKit/OCTPullRequestComment.m
@@ -11,43 +11,24 @@
 
 @implementation OCTPullRequestComment
 
-@synthesize body = _body;
 @synthesize path = _path;
 @synthesize position = _position;
 @synthesize commitSHA = _commitSHA;
-@synthesize commenterLogin = _commenterLogin;
-@synthesize creationDate = _creationDate;
-@synthesize updatedDate = _updatedDate;
 
 #pragma mark MTLJSONSerializing
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return [super.JSONKeyPathsByPropertyKey mtl_dictionaryByAddingEntriesFromDictionary:@{
-		@"HTMLURL": @"_links.html.href",
 		@"pullRequestAPIURL": @"_links.pull_request.href",
 		@"commenterLogin": @"user.login",
 		@"commitSHA": @"commit_id",
 		@"originalCommitSHA": @"original_commit_id",
-		@"creationDate": @"created_at",
-		@"updatedDate": @"updated_at",
 		@"originalPosition": @"original_position"
 	}];
 }
 
-+ (NSValueTransformer *)HTMLURLJSONTransformer {
-	return [NSValueTransformer valueTransformerForName:MTLURLValueTransformerName];
-}
-
 + (NSValueTransformer *)pullRequestAPIURLJSONTransformer {
 	return [NSValueTransformer valueTransformerForName:MTLURLValueTransformerName];
-}
-
-+ (NSValueTransformer *)creationDateJSONTransformer {
-	return [NSValueTransformer valueTransformerForName:OCTDateValueTransformerName];
-}
-
-+ (NSValueTransformer *)updatedDateJSONTransformer {
-	return [NSValueTransformer valueTransformerForName:OCTDateValueTransformerName];
 }
 
 @end

--- a/OctoKitTests/OCTPullRequestCommentSpec.m
+++ b/OctoKitTests/OCTPullRequestCommentSpec.m
@@ -31,6 +31,7 @@ NSDictionary *representation = @{
 	},
 	@"created_at": @"2011-04-14T16:00:49Z",
 	@"updated_at": @"2011-04-14T16:15:00Z",
+	@"html_url": @"https://github.com/octocat/Hello-World/pull/1#discussion-diff-1",
 	@"_links": @{
 		@"self": @{
 			@"href": @"https://api.github.com/octocat/Hello-World/pulls/comments/1"


### PR DESCRIPTION
Based on some discussion in #99 I believe its safe to use html_url for PullRequestReview comments.

I did some basic checking on URLs like this:

https://api.github.com/repos/octokit/octokit.objc/pulls/110/comments 

and `html_url` was available. Also `pull_request_url` is available. Not sure if using that would be better thank the _links stuff.
