### PR TITLE
Assume an OCTServer supports passwordAuthentication by default.

### DIFF
--- a/OctoKit/OCTServerMetadata.m
+++ b/OctoKit/OCTServerMetadata.m
@@ -18,4 +18,15 @@
 	}];
 }
 
+- (instancetype)init {
+	self = [super init];
+	if (self == nil) return nil;
+
+	// Assume any servers that don't have the verifiable_password_authentication
+	// key support password authentication
+	_supportsPasswordAuthentication = YES;
+
+	return self;
+}
+
 @end


### PR DESCRIPTION
`supportsPasswordAuthentication` should default to `YES` to support enterprise servers that have the `/meta` endpoint but don't yet have the `verifiable_password_authentication` key.
