### PR TITLE
Replace commenterLogin's with full OCTUser objects on comments.

### DIFF
--- a/OctoKit/OCTComment.h
+++ b/OctoKit/OCTComment.h
@@ -8,11 +8,13 @@
 
 #import <Foundation/Foundation.h>
 
+@class OCTUser;
+
 // A comment can be added to an issue, pull request, or commit.
 @protocol OCTComment <NSObject>
 
 // The login of the user who created this comment.
-@property (nonatomic, copy, readonly) NSString *commenterLogin;
+@property (nonatomic, copy, readonly) OCTUser *commenter;
 
 // The date at which the comment was originally created.
 @property (nonatomic, copy, readonly) NSDate *creationDate;

--- a/OctoKit/OCTCommitComment.m
+++ b/OctoKit/OCTCommitComment.m
@@ -7,6 +7,7 @@
 //
 
 #import "OCTCommitComment.h"
+#import "OCTUser.h"
 #import "NSValueTransformer+OCTPredefinedTransformerAdditions.h"
 
 @implementation OCTCommitComment
@@ -15,7 +16,7 @@
 @synthesize path = _path;
 @synthesize position = _position;
 @synthesize commitSHA = _commitSHA;
-@synthesize commenterLogin = _commenterLogin;
+@synthesize commenter = _commenter;
 @synthesize creationDate = _creationDate;
 @synthesize updatedDate = _updatedDate;
 
@@ -25,7 +26,7 @@
 	return [super.JSONKeyPathsByPropertyKey mtl_dictionaryByAddingEntriesFromDictionary:@{
 		@"HTMLURL": @"html_url",
 		@"commitSHA": @"commit_id",
-		@"commenterLogin": @"user.login",
+		@"commenter": @"user",
 		@"creationDate": @"created_at",
 		@"updatedDate": @"updated_at",
 	}];
@@ -41,6 +42,10 @@
 
 + (NSValueTransformer *)updatedDateJSONTransformer {
 	return [NSValueTransformer valueTransformerForName:OCTDateValueTransformerName];
+}
+
++ (NSValueTransformer *)commenterJSONTransformer {
+	return [NSValueTransformer mtl_JSONDictionaryTransformerWithModelClass:OCTUser.class];
 }
 
 @end

--- a/OctoKit/OCTIssueComment.m
+++ b/OctoKit/OCTIssueComment.m
@@ -7,12 +7,13 @@
 //
 
 #import "OCTIssueComment.h"
+#import "OCTUser.h"
 #import "NSValueTransformer+OCTPredefinedTransformerAdditions.h"
 
 @implementation OCTIssueComment
 
 @synthesize body = _body;
-@synthesize commenterLogin = _commenterLogin;
+@synthesize commenter = _commenter;
 @synthesize creationDate = _creationDate;
 @synthesize updatedDate = _updatedDate;
 
@@ -21,7 +22,7 @@
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return [super.JSONKeyPathsByPropertyKey mtl_dictionaryByAddingEntriesFromDictionary:@{
 		@"HTMLURL": @"html_url",
-		@"commenterLogin": @"user.login",
+		@"commenter": @"user",
 		@"creationDate": @"created_at",
 		@"updatedDate": @"updated_at",
 	}];
@@ -38,4 +39,9 @@
 + (NSValueTransformer *)updatedDateJSONTransformer {
 	return [NSValueTransformer valueTransformerForName:OCTDateValueTransformerName];
 }
+
++ (NSValueTransformer *)commenterJSONTransformer {
+	return [NSValueTransformer mtl_JSONDictionaryTransformerWithModelClass:OCTUser.class];
+}
+
 @end

--- a/OctoKit/OCTPullRequestComment.m
+++ b/OctoKit/OCTPullRequestComment.m
@@ -20,7 +20,6 @@
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return [super.JSONKeyPathsByPropertyKey mtl_dictionaryByAddingEntriesFromDictionary:@{
 		@"pullRequestAPIURL": @"_links.pull_request.href",
-		@"commenterLogin": @"user.login",
 		@"commitSHA": @"commit_id",
 		@"originalCommitSHA": @"original_commit_id",
 		@"originalPosition": @"original_position",

--- a/OctoKitTests/OCTCommitCommentSpec.m
+++ b/OctoKitTests/OCTCommitCommentSpec.m
@@ -20,19 +20,15 @@ NSDictionary *representation = @{
 	@"position": @4,
 	@"line": @14,
 	@"commit_id": @"6dcb09b5b57875f334f61aebed695e2e4193db5e",
+	@"created_at": @"2011-04-14T16:00:49Z",
+	@"updated_at": @"2011-04-14T16:15:00Z",
 	@"user": @{
 		@"login": @"octocat",
-
-		// Omitted because the JSON parsing does not preserve these keys.
-		/*
 		@"id": @1,
 		@"avatar_url": @"https://github.com/images/error/octocat_happy.gif",
 		@"gravatar_id": @"somehexcode",
 		@"url": @"https://api.github.com/users/octocat"
-		*/
-	},
-	@"created_at": @"2011-04-14T16:00:49Z",
-	@"updated_at": @"2011-04-14T16:15:00Z"
+	}
 };
 
 __block OCTCommitComment *comment;
@@ -46,10 +42,6 @@ itShouldBehaveLike(OCTObjectArchivingSharedExamplesName, ^{
 	return @{ OCTObjectKey: comment };
 });
 
-itShouldBehaveLike(OCTObjectExternalRepresentationSharedExamplesName, ^{
-	return @{ OCTObjectKey: comment, OCTObjectExternalRepresentationKey: representation };
-});
-
 it(@"should initialize", ^{
 	expect(comment.objectID).to.equal(@"1");
 	expect(comment.HTMLURL).to.equal([NSURL URLWithString:@"https://github.com/octocat/Hello-World/commit/6dcb09b5b57875f334f61aebed695e2e4193db5e#commitcomment-1"]);
@@ -59,6 +51,9 @@ it(@"should initialize", ^{
 	expect(comment.body).to.equal(@"Great stuff");
 	expect(comment.path).to.equal(@"file1.txt");
 	expect(comment.position).to.equal(@(4));
+	expect(comment.commenter.objectID).to.equal(@"1");
+	expect(comment.commenter.login).to.equal(@"octocat");
+	expect(comment.commenter.avatarURL).to.equal([NSURL URLWithString:@"https://github.com/images/error/octocat_happy.gif"]);
 });
 
 SpecEnd

--- a/OctoKitTests/OCTIssueCommentSpec.m
+++ b/OctoKitTests/OCTIssueCommentSpec.m
@@ -7,7 +7,9 @@
 //
 
 #import "OCTIssueComment.h"
+#import "OCTUser.h"
 #import "OCTObjectSpec.h"
+
 
 SpecBegin(OCTIssueComment)
 
@@ -17,15 +19,11 @@ NSDictionary *representation = @{
 	@"html_url": @"https://github.com/octocat/Hello-World/issues/1347#issuecomment-1",
 	@"body": @"Me too",
 	@"user": @{
-		@"login": @"octocat",
-
-		// Omitted because the JSON parsing does not preserve these keys.
-		/*
 		 @"id": @1,
+		 @"login": @"octocat",
 		 @"avatar_url": @"https://github.com/images/error/octocat_happy.gif",
 		 @"gravatar_id": @"somehexcode",
 		 @"url": @"https://api.github.com/users/octocat"
-		 */
 	},
 	@"created_at": @"2011-04-14T16:00:49Z",
 	@"updated_at": @"2011-04-14T18:00:49Z"
@@ -48,6 +46,9 @@ it(@"should initialize", ^{
 	expect(comment.creationDate).to.equal([[[ISO8601DateFormatter alloc] init] dateFromString:@"2011-04-14T16:00:49Z"]);
 	expect(comment.updatedDate).to.equal([[[ISO8601DateFormatter alloc] init] dateFromString:@"2011-04-14T18:00:49Z"]);
 	expect(comment.HTMLURL).to.equal([NSURL URLWithString:@"https://github.com/octocat/Hello-World/issues/1347#issuecomment-1"]);
+	expect(comment.commenter.objectID).to.equal(@"1");
+	expect(comment.commenter.login).to.equal(@"octocat");
+	expect(comment.commenter.avatarURL).to.equal([NSURL URLWithString:@"https://github.com/images/error/octocat_happy.gif"]);
 });
 
 SpecEnd

--- a/OctoKitTests/OCTPullRequestCommentSpec.m
+++ b/OctoKitTests/OCTPullRequestCommentSpec.m
@@ -21,14 +21,10 @@ NSDictionary *representation = @{
 	@"commit_id": @"6dcb09b5b57875f334f61aebed695e2e4193db5e",
 	@"user": @{
 		@"login": @"octocat",
-
-		// Omitted because the JSON parsing does not preserve these keys.
-		/*
-		@"id": @1,
 		@"avatar_url": @"https://github.com/images/error/octocat_happy.gif",
+		@"id": @1,
 		@"gravatar_id": @"somehexcode",
 		@"url": @"https://api.github.com/users/octocat"
-		*/
 	},
 	@"created_at": @"2011-04-14T16:00:49Z",
 	@"updated_at": @"2011-04-14T16:15:00Z",
@@ -69,6 +65,9 @@ it(@"should initialize", ^{
 	expect(comment.path).to.equal(@"file1.txt");
 	expect(comment.body).to.equal(@"Great stuff");
 	expect(comment.commitSHA).to.equal(@"6dcb09b5b57875f334f61aebed695e2e4193db5e");
+	expect(comment.commenter.objectID).to.equal(@"1");
+	expect(comment.commenter.login).to.equal(@"octocat");
+	expect(comment.commenter.avatarURL).to.equal([NSURL URLWithString:@"https://github.com/images/error/octocat_happy.gif"]);
 });
 
 SpecEnd


### PR DESCRIPTION
I think most apps will want the full OCTUser object, since it will have the user login, name, and avatar URL.