### PR TITLE
Trim trailing slashes in Enterprise URLs

### DIFF
--- a/OctoKit/OCTClient.m
+++ b/OctoKit/OCTClient.m
@@ -403,7 +403,12 @@ static NSString *OCTClientOAuthClientSecret = nil;
 
 		NSString *scope = [[self scopesArrayFromScopes:scopes] componentsJoinedByString:@","];
 
-		NSString *URLString = [[NSString alloc] initWithFormat:@"%@/login/oauth/authorize?client_id=%@&scope=%@&state=%@", server.baseWebURL, clientID, scope, uuidString];
+		// Trim trailing slashes from URL entered by the user, so we don't open
+		// their web browser to a URL that contains empty path components.
+		NSCharacterSet *slashSet = [NSCharacterSet characterSetWithCharactersInString:@"/"];
+		NSString *baseURLString = [server.baseWebURL.absoluteString stringByTrimmingCharactersInSet:slashSet];
+
+		NSString *URLString = [[NSString alloc] initWithFormat:@"%@/login/oauth/authorize?client_id=%@&scope=%@&state=%@", baseURLString, clientID, scope, uuidString];
 		NSURL *webURL = [NSURL URLWithString:URLString];
 
 		if (![self openURL:webURL]) {


### PR DESCRIPTION
Otherwise, we might open the browser to something like `https://hostname//login…`, which will fail miserably.
