### PR TITLE
Update URLs to Mantle repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/AFNetworking/AFNetworking.git
 [submodule "External/Mantle"]
 	path = External/Mantle
-	url = https://github.com/github/Mantle.git
+	url = https://github.com/MantleFramework/Mantle.git
 [submodule "External/ReactiveCocoa"]
 	path = External/ReactiveCocoa
 	url = https://github.com/ReactiveCocoa/ReactiveCocoa.git

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 OctoKit is a Cocoa and Cocoa Touch framework for interacting with the [GitHub
 API](http://developer.github.com), built using
 [AFNetworking](https://github.com/AFNetworking/AFNetworking),
-[Mantle](https://github.com/github/Mantle), and
+[Mantle](https://github.com/MantleFramework/Mantle), and
 [ReactiveCocoa](https://github.com/ReactiveCocoa/ReactiveCocoa).
 
 ## Making Requests


### PR DESCRIPTION
This change isn’t strictly necessary due to automatic redirection, but let’s keep our links fresh.
