### PR TITLE
Fix retain cycle in -oct_parsedResults

### DIFF
--- a/OctoKit/RACSignal+OCTClientAdditions.m
+++ b/OctoKit/RACSignal+OCTClientAdditions.m
@@ -13,7 +13,7 @@
 
 - (RACSignal *)oct_parsedResults {
 	return [self map:^(OCTResponse *response) {
-		NSAssert([response isKindOfClass:OCTResponse.class], @"Expected %@ to be an OCTResponse.", response);
+		NSCAssert([response isKindOfClass:OCTResponse.class], @"Expected %@ to be an OCTResponse.", response);
 		return response.parsedResult;
 	}];
 }


### PR DESCRIPTION
Because `NSAssert` is a huge trollface. Hopefully fixes #142.

@jacksonh Can you give this branch a try?
