### PR TITLE
Fix error when trying to login under iOS 7

### DIFF
--- a/OctoKit/OCTClient.m
+++ b/OctoKit/OCTClient.m
@@ -465,11 +465,11 @@ static NSString *OCTClientOAuthClientSecret = nil;
 
 	#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
 	if ([UIApplication.sharedApplication canOpenURL:URL]) {
-        [UIApplication.sharedApplication openURL:URL];
-        return YES;
-    } else {
-        return NO;
-    }
+		[UIApplication.sharedApplication openURL:URL];
+		return YES;
+	} else {
+		return NO;
+	}
 	#else
 	return [NSWorkspace.sharedWorkspace openURL:URL];
 	#endif


### PR DESCRIPTION
I tried to login under iOS 7 but it ouputs the `no default web browser` message. It then launches Safari and shows the Login page, but the subscriber success block is not called since the error block was called before.

This fixes it for me.

Thanks,

Piet.
