### PR TITLE
Add a rawLogin after logging in through the web flow.

### DIFF
--- a/OctoKit/OCTClient.m
+++ b/OctoKit/OCTClient.m
@@ -385,7 +385,10 @@ static NSString *OCTClientOAuthClientSecret = nil;
 			return [client fetchUserInfo];
 		}]
 		doNext:^(OCTUser *user) {
-			client.user = user;
+			NSMutableDictionary *userDict = [user.dictionaryValue mutableCopy] ?: [NSMutableDictionary dictionary];
+			if (user.rawLogin == nil) userDict[@keypath(user.rawLogin)] = user.login;
+			OCTUser *userWithRawLogin = [OCTUser modelWithDictionary:userDict error:NULL];
+			client.user = userWithRawLogin;
 		}]
 		mapReplace:client]
 		replayLazily]


### PR DESCRIPTION
Set the `rawLogin` after logging in via the web flow.

/cc @alanjrogers 

![](http://data2.whicdn.com/images/30656658/large.jpg)
