### PR TITLE
Return a new client when following HTTPS redirects on a client with an HTTP base URL

### DIFF
--- a/OctoKit/OCTClient.m
+++ b/OctoKit/OCTClient.m
@@ -917,7 +917,7 @@ static NSString *OCTClientOAuthClientSecret = nil;
 			break;
 	}
 
-	if (operation.userInfo[OCTClientErrorRequestStateRedirected]) {
+	if (operation.userInfo[OCTClientErrorRequestStateRedirected] != nil) {
 		errorCode = OCTClientErrorUnsupportedServerScheme;
 	}
 


### PR DESCRIPTION
Previous we returned the original client when following HTTPS redirects on a client with an HTTP base URL. We now return a new client with an HTTPS server when fetching an oauth token.
