### PR TITLE
[WIP] Mantle 2.0

### DIFF
--- a/OctoKit/NSValueTransformer+OCTPredefinedTransformerAdditions.m
+++ b/OctoKit/NSValueTransformer+OCTPredefinedTransformerAdditions.m
@@ -19,7 +19,7 @@ NSString * const OCTDateValueTransformerName = @"OCTDateValueTransformerName";
 + (void)load {
 	@autoreleasepool {
 		MTLValueTransformer *dateValueTransformer = [MTLValueTransformer
-			reversibleTransformerWithForwardBlock:^ id (id dateOrDateString) {
+			transformerUsingForwardBlock:^ id (id dateOrDateString, BOOL *success, NSError **error) {
 				// Some old model versions would serialize NSDates directly, so
 				// handle that case too.
 				if ([dateOrDateString isKindOfClass:NSDate.class]) {
@@ -27,11 +27,17 @@ NSString * const OCTDateValueTransformerName = @"OCTDateValueTransformerName";
 				} else if ([dateOrDateString isKindOfClass:NSString.class]) {
 					return [NSDateFormatter oct_dateFromString:dateOrDateString];
 				} else {
+					if (success != NULL) *success = NO;
+
 					return nil;
 				}
 			}
-			reverseBlock:^ id (NSDate *date) {
-				if (![date isKindOfClass:NSDate.class]) return nil;
+			reverseBlock:^ id (NSDate *date, BOOL *success, NSError **error) {
+				if (![date isKindOfClass:NSDate.class]) {
+					if (success != NULL) *success = NO;
+
+					return nil;
+				}
 				return [NSDateFormatter oct_stringFromDate:date];
 			}];
 		

--- a/OctoKit/NSValueTransformer+OCTPredefinedTransformerAdditions.m
+++ b/OctoKit/NSValueTransformer+OCTPredefinedTransformerAdditions.m
@@ -26,6 +26,8 @@ NSString * const OCTDateValueTransformerName = @"OCTDateValueTransformerName";
 					return dateOrDateString;
 				} else if ([dateOrDateString isKindOfClass:NSString.class]) {
 					return [NSDateFormatter oct_dateFromString:dateOrDateString];
+				} else if (dateOrDateString == NSNull.null || dateOrDateString == nil) {
+					return nil;
 				} else {
 					if (success != NULL) *success = NO;
 

--- a/OctoKit/OCTAccessToken.m
+++ b/OctoKit/OCTAccessToken.m
@@ -21,9 +21,9 @@
 + (NSValueTransformer *)tokenJSONTransformer {
 	// We want to prevent the token from being serialized out, so the reverse
 	// transform will simply yield nil instead of the token itself.
-	return [MTLValueTransformer reversibleTransformerWithForwardBlock:^(NSString *token) {
+	return [MTLValueTransformer transformerUsingForwardBlock:^(NSString *token, BOOL *success, NSError **error) {
 		return token;
-	} reverseBlock:^ id (NSString *token) {
+	} reverseBlock:^id(id value, BOOL *success, NSError **error) {
 		return nil;
 	}];
 }

--- a/OctoKit/OCTAuthorization.m
+++ b/OctoKit/OCTAuthorization.m
@@ -15,9 +15,9 @@
 + (NSValueTransformer *)tokenJSONTransformer {
 	// We want to prevent the token from being serialized out, so the reverse
 	// transform will simply yield nil instead of the token itself.
-	return [MTLValueTransformer reversibleTransformerWithForwardBlock:^(NSString *token) {
+	return [MTLValueTransformer transformerUsingForwardBlock:^(NSString *token, BOOL *success, NSError **error) {
 		return token;
-	} reverseBlock:^ id (NSString *token) {
+	} reverseBlock:^id(id value, BOOL *success, NSError **error) {
 		return nil;
 	}];
 }

--- a/OctoKit/OCTClient+Gists.m
+++ b/OctoKit/OCTClient+Gists.m
@@ -27,7 +27,11 @@
 
 	if (!self.authenticated) return [RACSignal error:self.class.authenticationRequiredError];
 
-	NSDictionary *parameters = [MTLJSONAdapter JSONDictionaryFromModel:edit];
+	NSError *error;
+	NSDictionary *parameters = [MTLJSONAdapter JSONDictionaryFromModel:edit error:&error];
+
+	if (parameters == nil) return [RACSignal error:error];
+
 	NSURLRequest *request = [self requestWithMethod:@"PATCH" path:[NSString stringWithFormat:@"gists/%@", gist.objectID] parameters:parameters notMatchingEtag:nil];
 	return [[self enqueueRequest:request resultClass:OCTGist.class] oct_parsedResults];
 }
@@ -37,7 +41,11 @@
 
 	if (!self.authenticated) return [RACSignal error:self.class.authenticationRequiredError];
 
-	NSDictionary *parameters = [MTLJSONAdapter JSONDictionaryFromModel:edit];
+	NSError *error;
+	NSDictionary *parameters = [MTLJSONAdapter JSONDictionaryFromModel:edit error:&error];
+
+	if (parameters == nil) return [RACSignal error:error];
+
 	NSURLRequest *request = [self requestWithMethod:@"POST" path:@"gists" parameters:parameters notMatchingEtag:nil];
 	return [[self enqueueRequest:request resultClass:OCTGist.class] oct_parsedResults];
 }

--- a/OctoKit/OCTClient+Git.m
+++ b/OctoKit/OCTClient+Git.m
@@ -41,8 +41,15 @@
 
 	NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
 	parameters[@"tree"] = [[treeEntries.rac_sequence
-		map:^(OCTTreeEntry *entry) {
-			return [MTLJSONAdapter JSONDictionaryFromModel:entry];
+		flattenMap:^(OCTTreeEntry *entry) {
+			NSError *error;
+			NSDictionary *JSONDictionary = [MTLJSONAdapter JSONDictionaryFromModel:entry error:&error];
+
+			if (JSONDictionary == nil) {
+				return [RACSignal error:error];
+			} else {
+				return [RACSignal return:JSONDictionary];
+			}
 		}]
 		array];
 

--- a/OctoKit/OCTClient+Keys.m
+++ b/OctoKit/OCTClient+Keys.m
@@ -29,7 +29,7 @@
 		@keypath(OCTPublicKey.new, title): title,
 	} error:NULL];
 	
-	NSURLRequest *request = [self requestWithMethod:@"POST" path:@"user/keys" parameters:[MTLJSONAdapter JSONDictionaryFromModel:publicKey] notMatchingEtag:nil];
+	NSURLRequest *request = [self requestWithMethod:@"POST" path:@"user/keys" parameters:[MTLJSONAdapter JSONDictionaryFromModel:publicKey error:NULL] notMatchingEtag:nil];
 
 	return [[self enqueueRequest:request resultClass:OCTPublicKey.class] oct_parsedResults];
 }

--- a/OctoKit/OCTDirectoryContent.m
+++ b/OctoKit/OCTDirectoryContent.m
@@ -13,9 +13,7 @@
 #pragma mark MTLJSONSerializing
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return [super.JSONKeyPathsByPropertyKey mtl_dictionaryByAddingEntriesFromDictionary:@{
-		@"size": NSNull.null,
-	}];
+	return [super.JSONKeyPathsByPropertyKey mtl_dictionaryByRemovingEntriesWithKeys:@[ @"size" ]];
 }
 
 @end

--- a/OctoKit/OCTEvent.m
+++ b/OctoKit/OCTEvent.m
@@ -62,7 +62,9 @@
 + (NSValueTransformer *)objectIDJSONTransformer {
 	// The "id" field for events comes through as a string, which matches the
 	// type of our objectID property.
-	return nil;
+	return [MTLValueTransformer transformerUsingReversibleBlock:^(id value, BOOL *success, NSError **error) {
+		return value;
+	}];
 }
 
 @end

--- a/OctoKit/OCTGist.m
+++ b/OctoKit/OCTGist.m
@@ -66,7 +66,9 @@
 + (NSValueTransformer *)objectIDJSONTransformer {
 	// The "id" field for gists comes through as a string, which matches the
 	// type of our objectID property.
-	return nil;
+	return [MTLValueTransformer transformerUsingReversibleBlock:^(id value, BOOL *success, NSError **error) {
+		return value;
+	}];
 }
 
 + (NSValueTransformer *)HTMLURLJSONTransformer {

--- a/OctoKit/OCTGist.m
+++ b/OctoKit/OCTGist.m
@@ -112,10 +112,12 @@
 #pragma mark MTLJSONSerializing
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
+	NSDictionary *oldImplicitMapping = [NSDictionary mtl_identityPropertyMapWithModel:self];
+
+	return [oldImplicitMapping mtl_dictionaryByAddingEntriesFromDictionary:@{
 		@"fileChanges": @"files",
 		@"publicGist": @"public",
-	};
+	}];
 }
 
 + (NSValueTransformer *)fileChangesJSONTransformer {

--- a/OctoKit/OCTGistFile.m
+++ b/OctoKit/OCTGistFile.m
@@ -29,7 +29,7 @@
 #pragma mark MTLJSONSerializing
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{};
+	return [NSDictionary mtl_identityPropertyMapWithModel:self];
 }
 
 @end

--- a/OctoKit/OCTIssueComment.m
+++ b/OctoKit/OCTIssueComment.m
@@ -18,6 +18,17 @@
 
 #pragma mark MTLJSONSerializing
 
++ (NSSet *)propertyKeys {
+	return [super.propertyKeys setByAddingObjectsFromArray:@[
+		// OCTComment
+		@"body",
+		@"commenterLogin",
+		@"creationDate",
+		@"updatedDate",
+	]];
+}
+
+
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return [super.JSONKeyPathsByPropertyKey mtl_dictionaryByAddingEntriesFromDictionary:@{
 		@"HTMLURL": @"html_url",

--- a/OctoKit/OCTIssueEvent.m
+++ b/OctoKit/OCTIssueEvent.m
@@ -35,13 +35,7 @@
 		@"reopened": @(OCTIssueActionReopened),
 	};
 
-	return [MTLValueTransformer
-		reversibleTransformerWithForwardBlock:^(NSString *actionName) {
-			return actionsByName[actionName];
-		}
-		reverseBlock:^(NSNumber *action) {
-			return [actionsByName allKeysForObject:action].lastObject;
-		}];
+	return [NSValueTransformer mtl_valueMappingTransformerWithDictionary:actionsByName];
 }
 
 #pragma mark NSKeyValueCoding

--- a/OctoKit/OCTNotification.m
+++ b/OctoKit/OCTNotification.m
@@ -27,12 +27,14 @@
 }
 
 + (NSValueTransformer *)objectIDJSONTransformer {
-	return [MTLValueTransformer transformerWithBlock:^ id (id num) {
+	return [MTLValueTransformer transformerUsingForwardBlock:^ id (id num, BOOL *success, NSError **error) {
 		if ([num isKindOfClass:NSString.class]) {
 			return num;
 		} else if ([num isKindOfClass:NSNumber.class]) {
 			return [num stringValue];
 		} else {
+			if (success != NULL) *success = NO;
+
 			return nil;
 		}
 	}];
@@ -65,12 +67,7 @@
 		@"Commit": @(OCTNotificationTypeCommit),
 	};
 
-	return [MTLValueTransformer
-		reversibleTransformerWithForwardBlock:^(NSString *name) {
-			return typesByName[name] ?: @(OCTNotificationTypeUnknown);
-		} reverseBlock:^(NSNumber *type) {
-			return [typesByName allKeysForObject:type].lastObject;
-		}];
+	return [NSValueTransformer mtl_valueMappingTransformerWithDictionary:typesByName];
 }
 
 @end

--- a/OctoKit/OCTObject.m
+++ b/OctoKit/OCTObject.m
@@ -53,10 +53,13 @@
 #pragma mark MTLJSONSerializing
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-		@"objectID": @"id",
-		@"server": NSNull.null,
-	};
+	NSMutableDictionary *oldImplicitMapping = [[NSDictionary mtl_identityPropertyMapWithModel:self] mutableCopy];
+
+	oldImplicitMapping[@"objectID"] = @"id";
+
+	[oldImplicitMapping removeObjectForKey:@"server"];
+
+	return oldImplicitMapping;
 }
 
 + (NSValueTransformer *)objectIDJSONTransformer {

--- a/OctoKit/OCTObject.m
+++ b/OctoKit/OCTObject.m
@@ -61,9 +61,9 @@
 
 + (NSValueTransformer *)objectIDJSONTransformer {
 	return [MTLValueTransformer
-		reversibleTransformerWithForwardBlock:^(NSNumber *num) {
+		transformerUsingForwardBlock:^(NSNumber *num, BOOL *success, NSError **error) {
 			return num.stringValue;
-		} reverseBlock:^ id (NSString *str) {
+		} reverseBlock:^ id (NSString *str, BOOL *success, NSError **error) {
 			if (str == nil) return nil;
 
 			return [NSDecimalNumber decimalNumberWithString:str];

--- a/OctoKit/OCTPullRequest.m
+++ b/OctoKit/OCTPullRequest.m
@@ -66,13 +66,7 @@
 		@"closed": @(OCTPullRequestStateClosed),
 	};
 
-	return [MTLValueTransformer
-		reversibleTransformerWithForwardBlock:^(NSString *stateName) {
-			return statesByName[stateName];
-		}
-		reverseBlock:^(NSNumber *state) {
-			return [statesByName allKeysForObject:state].lastObject;
-		}];
+	return [NSValueTransformer mtl_valueMappingTransformerWithDictionary:statesByName];
 }
 
 + (NSValueTransformer *)creationDateJSONTransformer {

--- a/OctoKit/OCTPullRequestEvent.m
+++ b/OctoKit/OCTPullRequestEvent.m
@@ -32,13 +32,7 @@
 		@"synchronized": @(OCTIssueActionSynchronized),
 	};
 
-	return [MTLValueTransformer
-		reversibleTransformerWithForwardBlock:^(NSString *actionName) {
-			return actionsByName[actionName];
-		}
-		reverseBlock:^(NSNumber *action) {
-			return [actionsByName allKeysForObject:action].lastObject;
-		}];
+	return [NSValueTransformer mtl_valueMappingTransformerWithDictionary:actionsByName];
 }
 
 #pragma mark NSKeyValueCoding

--- a/OctoKit/OCTPushEvent.m
+++ b/OctoKit/OCTPushEvent.m
@@ -26,15 +26,18 @@
 	static NSString * const branchRefPrefix = @"refs/heads/";
 
 	return [MTLValueTransformer
-		reversibleTransformerWithForwardBlock:^ id (NSString *ref) {
+		transformerUsingForwardBlock:^ id (NSString *ref, BOOL *success, NSError **error) {
 			if (![ref hasPrefix:branchRefPrefix]) {
 				NSLog(@"%s: Unrecognized ref prefix: %@", __func__, ref);
+
+				if (success != NULL) *success = NO;
+
 				return nil;
 			}
 
 			return [ref substringFromIndex:branchRefPrefix.length];
 		}
-		reverseBlock:^(NSString *branch) {
+		reverseBlock:^(NSString *branch, BOOL *success, NSError **error) {
 			return [branchRefPrefix stringByAppendingString:branch];
 		}];
 }

--- a/OctoKit/OCTRefEvent.m
+++ b/OctoKit/OCTRefEvent.m
@@ -27,13 +27,7 @@
 		@"repository": @(OCTRefTypeRepository),
 	};
 
-	return [MTLValueTransformer
-		reversibleTransformerWithForwardBlock:^(NSString *typeName) {
-			return typesByName[typeName];
-		}
-		reverseBlock:^(NSNumber *type) {
-			return [typesByName allKeysForObject:type].lastObject;
-		}];
+	return [NSValueTransformer mtl_valueMappingTransformerWithDictionary:typesByName];
 }
 
 + (NSValueTransformer *)eventTypeJSONTransformer {
@@ -42,13 +36,7 @@
 		@"DeleteEvent": @(OCTRefEventDeleted),
 	};
 
-	return [MTLValueTransformer
-		reversibleTransformerWithForwardBlock:^(NSString *typeName) {
-			return typesByName[typeName];
-		}
-		reverseBlock:^(NSNumber *type) {
-			return [typesByName allKeysForObject:type].lastObject;
-		}];
+	return [NSValueTransformer mtl_valueMappingTransformerWithDictionary:typesByName];
 }
 
 #pragma mark NSKeyValueCoding

--- a/OctoKit/OCTTreeEntry.m
+++ b/OctoKit/OCTTreeEntry.m
@@ -46,13 +46,7 @@
 		@"commit": @(OCTTreeEntryTypeCommit),
 	};
 
-	return [MTLValueTransformer
-		reversibleTransformerWithForwardBlock:^(NSString *typeName) {
-			return typeByName[typeName];
-		}
-		reverseBlock:^(NSNumber *type) {
-			return [typeByName allKeysForObject:type].lastObject;
-		}];
+	return [NSValueTransformer mtl_valueMappingTransformerWithDictionary:typeByName];
 }
 
 + (NSValueTransformer *)modeJSONTransformer {
@@ -64,13 +58,7 @@
 		@"120000": @(OCTTreeEntryModeSymlink),
 	};
 
-	return [MTLValueTransformer
-		reversibleTransformerWithForwardBlock:^(NSString *typeName) {
-			return typeByName[typeName];
-		}
-		reverseBlock:^(NSNumber *type) {
-			return [typeByName allKeysForObject:type].lastObject;
-		}];
+	return [NSValueTransformer mtl_valueMappingTransformerWithDictionary:typeByName];
 }
 
 #pragma mark NSObject

--- a/OctoKitTests/OCTAuthorizationSpec.m
+++ b/OctoKitTests/OCTAuthorizationSpec.m
@@ -31,7 +31,7 @@ it(@"should initialize from an external representation", ^{
 
 it(@"shouldn't include the token in the serialized representation", ^{
 	NSDictionary *representation = [MTLJSONAdapter JSONDictionaryFromModel:authorization error:NULL];
-	expect(representation[@"token"]).to.equal(NSNull.null);
+	expect(representation[@"token"]).to.beNil();
 });
 
 itShouldBehaveLike(OCTObjectArchivingSharedExamplesName, ^{

--- a/OctoKitTests/OCTAuthorizationSpec.m
+++ b/OctoKitTests/OCTAuthorizationSpec.m
@@ -30,7 +30,7 @@ it(@"should initialize from an external representation", ^{
 });
 
 it(@"shouldn't include the token in the serialized representation", ^{
-	NSDictionary *representation = [MTLJSONAdapter JSONDictionaryFromModel:authorization];
+	NSDictionary *representation = [MTLJSONAdapter JSONDictionaryFromModel:authorization error:NULL];
 	expect(representation[@"token"]).to.equal(NSNull.null);
 });
 

--- a/OctoKitTests/OCTGistEditSpec.m
+++ b/OctoKitTests/OCTGistEditSpec.m
@@ -44,7 +44,7 @@ describe(@"JSON serialization", ^{
 			},
 		};
 		
-		NSDictionary *editDict = [MTLJSONAdapter JSONDictionaryFromModel:edit];
+		NSDictionary *editDict = [MTLJSONAdapter JSONDictionaryFromModel:edit error:NULL];
 		expect(editDict).to.equal(expectedDict);
 	});
 });

--- a/OctoKitTests/OCTObjectSpec.m
+++ b/OctoKitTests/OCTObjectSpec.m
@@ -48,7 +48,11 @@ sharedExamplesFor(OCTObjectExternalRepresentationSharedExamplesName, ^(NSDiction
 	});
 
 	it(@"should be equal in all values that exist in both external representations", ^{
-		NSDictionary *JSONDictionary = [MTLJSONAdapter JSONDictionaryFromModel:obj];
+		NSError *error;
+		NSDictionary *JSONDictionary = [MTLJSONAdapter JSONDictionaryFromModel:obj error:&error];
+
+		expect(JSONDictionary).notTo.beNil();
+		expect(error).to.beNil();
 
 		[representation enumerateKeysAndObjectsUsingBlock:^(NSString *key, id expectedValue, BOOL *stop) {
 			id value = JSONDictionary[key];

--- a/OctoKitTests/OCTUserSpec.m
+++ b/OctoKitTests/OCTUserSpec.m
@@ -159,7 +159,7 @@ describe(@"enterprise user", ^{
 	itShouldBehaveLike(OCTObjectExternalRepresentationSharedExamplesName, ^{
 		// The "url" key isn't translated back for creating the external
 		// representation, so remove it.
-		NSDictionary *modifiedRepresentation = [representation mtl_dictionaryByRemovingEntriesWithKeys:[NSSet setWithObject:@"url"]];
+		NSDictionary *modifiedRepresentation = [representation mtl_dictionaryByRemovingEntriesWithKeys:@[ @"url" ]];
 
 		return @{ OCTObjectKey: user, OCTObjectExternalRepresentationKey: modifiedRepresentation };
 	});


### PR DESCRIPTION
:rotating_light: NOT READY TO MERGE :rotating_light:

This updates Octokit.objc to the upcoming 2.0 version of Mantle.

This serves primarily as a test of the migration path and to test the stability of Mantle 2.0.

Some of my findings:

* The change from implicit to explicit mappings is not made obvious by any warnings (not sure if it could be). I think this will bite some people in the back if don't have good test coverage for their model layer but I'm not sure how we can help them. I started by using `+mtl_identityPropertyMapWithModel:` to restore old behavior but I'll change that to explicit mappings later. 
* Similarly, due to the absence of implicit mappings, I had a couple of parsing attempts fail due to an [illegal JSON mapping](https://github.com/Mantle/Mantle/pull/294). I'd like to give that particular error a higher visibility, maybe we can log it to the console the first time it occurs? Since you could consider it a programmer error, we could also throw an exception.
* Updating existing block-based transformers to the new error handling variety means untangling the different meanings of `nil`. I guess clients are on their own here but I appreciate any feedback on the calls I made for Octokit. 
* Was `+mtl_dictionaryByRemovingEntriesWithKeys:` a public method? It changes its API from taking an `NSSet` to an `NSArray`. If it was public, it would be nice if we kept the old one around and deprecated it instead.

/cc @jspahrsummers
