### PR TITLE
Add language from repository response to parsed OCTRepository object

### DIFF
--- a/OctoKit/OCTRepository.h
+++ b/OctoKit/OCTRepository.h
@@ -26,6 +26,9 @@
 // The description of this repository.
 @property (nonatomic, copy, readonly) NSString *repoDescription;
 
+// The language of this repository.
+@property (nonatomic, copy, readonly) NSString *language;
+
 // Whether this repository is private to the owner.
 @property (nonatomic, assign, getter = isPrivate, readonly) BOOL private;
 

--- a/OctoKit/OCTRepository.m
+++ b/OctoKit/OCTRepository.m
@@ -67,6 +67,7 @@ static NSString *const OCTRepositoryHTMLIssuesPath = @"issues";
 		dictionaryValue[@"ownerLogin"] = owner[@"login"];
 	}
 
+	dictionaryValue[@"language"] = externalRepresentation[@"language"] ?: NSNull.null;
 	dictionaryValue[@"repoDescription"] = externalRepresentation[@"description"] ?: NSNull.null;
 	dictionaryValue[@"private"] = externalRepresentation[@"private"] ?: @NO;
 	dictionaryValue[@"fork"] = externalRepresentation[@"fork"] ?: @NO;


### PR DESCRIPTION
I noticed that the OCTRepository object doesn't contain the full payload that the endpoint sends, and I needed the language in a project that I am working on.
