### PR TITLE
Swift compatible enums

### DIFF
--- a/OctoKit/OCTClient+Git.h
+++ b/OctoKit/OCTClient+Git.h
@@ -13,10 +13,10 @@
 // The types of content encodings
 //   OCTContentEncodingUTF8   - utf-8
 //   OCTContentEncodingBase64 - base64
-typedef enum : NSUInteger {
+typedef NS_ENUM(NSInteger, OCTContentEncoding) {
 	OCTContentEncodingUTF8,
 	OCTContentEncodingBase64
-} OCTContentEncoding;
+};
 
 @interface OCTClient (Git)
 

--- a/OctoKit/OCTClient.h
+++ b/OctoKit/OCTClient.h
@@ -137,7 +137,7 @@ extern NSString * const OCTClientErrorMessagesKey;
 // OCTClientAuthorizationScopesPublicKeyAdmin   - Full administrative access to the user's public SSH keys,
 //                                                including permission to delete them. This includes
 //                                                OCTClientAuthorizationScopesPublicKeyWrite.
-typedef enum : NSUInteger {
+typedef NS_OPTIONS(NSUInteger, OCTClientAuthorizationScopes) {
 	OCTClientAuthorizationScopesPublicReadOnly = 1 << 0,
 
 	OCTClientAuthorizationScopesUserEmail = 1 << 1,
@@ -156,16 +156,16 @@ typedef enum : NSUInteger {
 	OCTClientAuthorizationScopesPublicKeyRead = 1 << 10,
 	OCTClientAuthorizationScopesPublicKeyWrite = 1 << 11,
 	OCTClientAuthorizationScopesPublicKeyAdmin = 1 << 12,
-} OCTClientAuthorizationScopes;
+};
 
 // The medium used to deliver the one-time password.
 //
 // OCTClientOneTimePasswordMediumSMS - Delivered via SMS.
 // OCTClientOneTimePasswordMediumApp - Delivered via an app.
-typedef enum : NSUInteger {
+typedef NS_ENUM(NSInteger, OCTClientOneTimePasswordMedium) {
 	OCTClientOneTimePasswordMediumSMS,
 	OCTClientOneTimePasswordMediumApp,
-} OCTClientOneTimePasswordMedium;
+};
 
 // Represents a single GitHub session.
 //

--- a/OctoKit/OCTIssueEvent.h
+++ b/OctoKit/OCTIssueEvent.h
@@ -23,13 +23,13 @@
 //                              sync'd with the underlying git state after a
 //                              failed hook or a force push.
 
-typedef enum : NSUInteger {
+typedef NS_ENUM(NSInteger, OCTIssueAction) {
     OCTIssueActionUnknown = 0,
     OCTIssueActionOpened,
     OCTIssueActionClosed,
     OCTIssueActionReopened,
     OCTIssueActionSynchronized
-} OCTIssueAction;
+};
 
 // An issue was opened or closed or somethin'.
 @interface OCTIssueEvent : OCTEvent

--- a/OctoKit/OCTMemberEvent.h
+++ b/OctoKit/OCTMemberEvent.h
@@ -15,10 +15,10 @@
 //                               will simply fail to be created.
 // OCTMemberActionAdded        - The user was added as a collaborator to the repository.
 
-typedef enum : NSUInteger {
+typedef NS_ENUM(NSInteger, OCTMemberAction) {
 	OCTMemberActionUnknown = 0,
 	OCTMemberActionAdded
-} OCTMemberAction;
+};
 
 // A user was added as a collaborator to a repository.
 @interface OCTMemberEvent : OCTEvent

--- a/OctoKit/OCTNotification.h
+++ b/OctoKit/OCTNotification.h
@@ -16,12 +16,12 @@
 // OCTNotificationTypeIssue       - A new issue, or a new comment on one.
 // OCTNotificationTypePullRequest - A new pull request, or a new comment on one.
 // OCTNotificationTypeCommit      - A new comment on a commit.
-typedef enum : NSUInteger {
+typedef NS_ENUM(NSInteger, OCTNotificationType) {
     OCTNotificationTypeUnknown,
 	OCTNotificationTypeIssue,
 	OCTNotificationTypePullRequest,
-	OCTNotificationTypeCommit,
-} OCTNotificationType;
+	OCTNotificationTypeCommit
+};
 
 // A notification of some type of activity.
 @interface OCTNotification : OCTObject

--- a/OctoKit/OCTPullRequest.h
+++ b/OctoKit/OCTPullRequest.h
@@ -15,10 +15,10 @@
 //
 // OCTPullRequestStateOpen   - The pull request is open.
 // OCTPullRequestStateClosed - The pull request is closed.
-typedef enum : NSUInteger {
+typedef NS_ENUM(NSInteger, OCTPullRequestState) {
     OCTPullRequestStateOpen,
     OCTPullRequestStateClosed
-} OCTPullRequestState;
+};
 
 // A pull request on a repository.
 @interface OCTPullRequest : OCTObject

--- a/OctoKit/OCTRefEvent.h
+++ b/OctoKit/OCTRefEvent.h
@@ -16,12 +16,12 @@
 // OCTRefTypeBranch     - A branch in a repository.
 // OCTRefTypeTag        - A tag in a repository.
 // OCTRefTypeRepository - A repository.
-typedef enum : NSUInteger {
+typedef NS_ENUM(NSInteger, OCTRefType) {
     OCTRefTypeUnknown = 0,
     OCTRefTypeBranch,
     OCTRefTypeTag,
     OCTRefTypeRepository
-} OCTRefType;
+};
 
 // The type of event that occurred around a reference.
 //
@@ -30,11 +30,11 @@ typedef enum : NSUInteger {
 //                      fail to be created.
 // OCTRefEventCreated - The reference was created on the server.
 // OCTRefEventDeleted - The reference was deleted on the server.
-typedef enum : NSUInteger {
+typedef NS_ENUM(NSInteger, OCTRefEventType) {
     OCTRefEventUnknown = 0,
     OCTRefEventCreated,
     OCTRefEventDeleted
-} OCTRefEventType;
+};
 
 // A git reference (branch or tag) was created or deleted.
 @interface OCTRefEvent : OCTEvent

--- a/OctoKit/OCTTreeEntry.h
+++ b/OctoKit/OCTTreeEntry.h
@@ -12,11 +12,11 @@
 //   OCTTreeEntryTypeBlob   - A blob of data.
 //   OCTTreeEntryTypeTree   - A tree of entries.
 //   OCTTreeEntryTypeCommit - A commit.
-typedef enum : NSUInteger {
+typedef NS_ENUM(NSInteger, OCTTreeEntryType) {
 	OCTTreeEntryTypeBlob,
 	OCTTreeEntryTypeTree,
-	OCTTreeEntryTypeCommit,
-} OCTTreeEntryType;
+	OCTTreeEntryTypeCommit
+};
 
 // The file mode of the entry.
 //   OCTTreeEntryModeFile         - File (blob) mode.
@@ -24,13 +24,13 @@ typedef enum : NSUInteger {
 //   OCTTreeEntryModeSubdirectory - Subdirectory (tree) mode.
 //   OCTTreeEntryModeSubmodule    - Submodule (commit) mode.
 //   OCTTreeEntryModeSymlink      - Blob which specifies the path of a symlink.
-typedef enum : NSUInteger {
+typedef NS_ENUM(NSInteger, OCTTreeEntryMode) {
 	OCTTreeEntryModeFile,
 	OCTTreeEntryModeExecutable,
 	OCTTreeEntryModeSubdirectory,
 	OCTTreeEntryModeSubmodule,
-	OCTTreeEntryModeSymlink,
-} OCTTreeEntryMode;
+	OCTTreeEntryModeSymlink
+};
 
 // A class cluster for git tree entries.
 @interface OCTTreeEntry : OCTObject


### PR DESCRIPTION
Change all enum definitions in OctoKit to use `NS_ENUM` or `NS_OPTIONS` where appropriate to resolve #187.

I’ve also changed the type of all the enums which were just that, enumerations, to be backed by `NSInteger` as that is what Apple recommends. The options enum is still being backed by a `NSUInteger` as recommended by Apple.

/cc @joeljfischer