### PR TITLE
Change the type of milestone parameter to NSNumber.

### DIFF
--- a/OctoKit/OCTClient+Issues.h
+++ b/OctoKit/OCTClient+Issues.h
@@ -26,6 +26,6 @@
 /// repository - The repository in which to create the issue. This must not be nil.
 ///
 /// Returns a signal which will send the created `OCTIssue` then complete, or error.
-- (RACSignal *)createIssueWithTitle:(NSString *)title body:(NSString *)body assignee:(NSString *)assignee milestone:(NSUInteger)milestone labels:(NSArray *)labels inRepository:(OCTRepository *)repository;
+- (RACSignal *)createIssueWithTitle:(NSString *)title body:(NSString *)body assignee:(NSString *)assignee milestone:(NSNumber *)milestone labels:(NSArray *)labels inRepository:(OCTRepository *)repository;
 
 @end

--- a/OctoKit/OCTClient+Issues.m
+++ b/OctoKit/OCTClient+Issues.m
@@ -10,14 +10,14 @@
 
 @implementation OCTClient (Issues)
 
-- (RACSignal *)createIssueWithTitle:(NSString *)title body:(NSString *)body assignee:(NSString *)assignee milestone:(NSUInteger)milestone labels:(NSArray *)labels inRepository:(OCTRepository *)repository {
+- (RACSignal *)createIssueWithTitle:(NSString *)title body:(NSString *)body assignee:(NSString *)assignee milestone:(NSNumber *)milestone labels:(NSArray *)labels inRepository:(OCTRepository *)repository {
 	NSParameterAssert(title != nil);
 	NSParameterAssert(repository != nil);
 	
 	NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
 	parameters[@"title"] = title;
-	parameters[@"milestone"] = @(milestone);
 	
+	if (milestone != nil) parameters[@"milestone"] = milestone;
 	if (body != nil) parameters[@"body"] = body;
 	if (assignee != nil) parameters[@"assignee"] = assignee;
 	if (labels != nil) parameters[@"labels"] = labels;


### PR DESCRIPTION
Change the type of milestone parameter to NSNumber, so user can pass nil when they don't need this parameter.