### PR TITLE
Fix bug.

### DIFF
--- a/OctoKit/OCTClient+Activity.m
+++ b/OctoKit/OCTClient+Activity.m
@@ -22,10 +22,10 @@
 	NSMutableURLRequest *request = [self requestWithMethod:@"GET" path:path parameters:nil];
 	return [[[self
 		enqueueRequest:request resultClass:nil]
-		map:^id(OCTResponse *response) {
+		map:^(OCTResponse *response) {
 			return @(response.statusCode == 204);
 		}]
-		catch:^RACSignal *(NSError *error) {
+		catch:^(NSError *error) {
 			NSNumber *statusCode = error.userInfo[OCTClientErrorHTTPStatusCodeKey];
 			if (statusCode.integerValue == 404) {
 				return [RACSignal return:@NO];

--- a/OctoKit/OCTClient+Activity.m
+++ b/OctoKit/OCTClient+Activity.m
@@ -9,6 +9,7 @@
 #import "OCTClient+Activity.h"
 #import "OCTClient+Private.h"
 #import "OCTRepository.h"
+#import "OCTResponse.h"
 #import <ReactiveCocoa/ReactiveCocoa.h>
 
 @implementation OCTClient (Activity)
@@ -21,7 +22,7 @@
 	NSMutableURLRequest *request = [self requestWithMethod:@"GET" path:path parameters:nil];
 	return [[[self
 		enqueueRequest:request resultClass:nil]
-		reduceEach:^(NSHTTPURLResponse *response, id _) {
+		map:^id(OCTResponse *response) {
 			return @(response.statusCode == 204);
 		}]
 		catch:^RACSignal *(NSError *error) {


### PR DESCRIPTION
The return value of method `[self enqueueRequest:request resultClass:nil]` that called in method `- (RACSignal *)hasUserStarredRepository:(OCTRepository *)repository` is a OCTResponse stream now.