### PR TITLE
Deprecate Objective-C client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**NOTE:** This repository is no longer supported or updated by GitHub. If you wish to continue to develop this code yourself, we recommend you fork it.
+
 # OctoKit
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 


### PR DESCRIPTION
GitHub is no longer actively maintaining the Objective-C client. This officially marks it as deprecated.

- [x] Get 👌  from @joshaber, @sbarnekow, and @jch
- [x] Remove from https://developer.github.com/v3/libraries/
- [x] Close all open PRs & Issues with link to this pull request
- [ ] Archive this repository

Closes #313
Closes #312
Closes #311
Closes #310
Closes #306
Closes #304
Closes #303
Closes #302
Closes #301
Closes #297
Closes #288
Closes #280
Closes #276
Closes #238
Closes #216
Closes #201
Closes #197
Closes #193
Closes #181
Closes #180
Closes #173
Closes #171
Closes #131
Closes #124
Closes #116
Closes #90
Closes #89
Closes #85
Closes #49
Closes #48
Closes #36
Closes #32
Closes #28